### PR TITLE
Corrigir deployment em produção a falhar

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-worker: npm run build && npm start
+worker: npm start

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "welcome-bot",
+  "name": "discord-bot",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "build": "tsc index.ts --resolveJsonModule --esModuleInterop --skipLibCheck",
-    "start": "node index.ts",
+    "build": "tsc -p .",
+    "start": "npm run build && node dist/index.js",
     "start.dev": "nodemon",
     "lint": "eslint . --ext .ts",
     "lint-and-fix": "eslint . --ext .ts --fix",


### PR DESCRIPTION
A branch master estava já desde há uns PRs atrás a falhar em produção tendo em conta que não estava nem a usar `ts-node` (que não é recomendado em produção), nem a correr o `node` no index.js transpilado.

Este Pull Request volta a colocar master como branch operacional.