### PR TITLE
Follow-up: Deploy em produção

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "build": "tsc -p .",
-    "start": "npm run build && node dist/index.js",
+    "build": "tsc",
+    "start": "node dist/index.js",
     "start.dev": "nodemon",
     "lint": "eslint . --ext .ts",
     "lint-and-fix": "eslint . --ext .ts --fix",


### PR DESCRIPTION
O PR anterior não resolveu o problema porque o build deve decorrer meramente no processo de build, pois o Heroku não tem acesso em runtime ao build.