### PR TITLE
Adicionar suporte a deployment no Fly.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM debian:bullseye as builder
+
+ARG NODE_VERSION=16.14.0
+
+RUN apt-get update; apt install -y curl
+RUN curl https://get.volta.sh | bash
+ENV VOLTA_HOME /root/.volta
+ENV PATH /root/.volta/bin:$PATH
+RUN volta install node@${NODE_VERSION}
+
+#######################################################################
+
+RUN mkdir /app
+WORKDIR /app
+
+# NPM will not install any package listed in "devDependencies" when NODE_ENV is set to "production",
+# to install all modules: "npm install --production=false".
+# Ref: https://docs.npmjs.com/cli/v9/commands/npm-install#description
+
+ENV NODE_ENV production
+
+COPY . .
+
+RUN npm install --production=false && npm run build
+FROM debian:bullseye
+
+LABEL fly_launch_runtime="nodejs"
+
+COPY --from=builder /root/.volta /root/.volta
+COPY --from=builder /app /app
+
+WORKDIR /app
+ENV NODE_ENV production
+ENV PATH /root/.volta/bin:$PATH
+
+CMD [ "npm", "run", "start" ]

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-worker: npm start

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,38 @@
+# fly.toml file generated for devpt-discord-bot on 2022-12-09T01:46:00+02:00
+
+app = "devpt-discord-bot"
+kill_signal = "SIGINT"
+kill_timeout = 5
+processes = []
+
+[env]
+
+[experimental]
+  allowed_public_ports = []
+  auto_rollback = true
+
+[[services]]
+  http_checks = []
+  internal_port = 8080
+  processes = ["app"]
+  protocol = "tcp"
+  script_checks = []
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+    type = "connections"
+
+  [[services.ports]]
+    force_https = true
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[services.tcp_checks]]
+    grace_period = "1s"
+    interval = "15s"
+    restart_limit = 0
+    timeout = "2s"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lint": "eslint . --ext .ts",
     "lint-and-fix": "eslint . --ext .ts --fix",
     "format": "prettier --write .",
-    "prepare": "husky install",
+    "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\"",
     "test": "vitest",
     "test:once": "vitest run",
     "coverage": "vitest run --coverage"


### PR DESCRIPTION
Dado à eliminação do free tier do Heroku, acabei por testar a alternativa do Fly.io.

Para tal, acabei por fazer os seguintes ajustes:
- Adição de suporte ao Fly.io adicionando o ficheiro `fly.toml` e um `Dockerfile`, ambos custom, criados automaticamente pelo Fly.io. Podem eventualmente vir a ser melhorados mas para uma solução de recurso, out-of-the-box, penso que serve perfeitamente.
- Remoção do ficheiro `Procfile` (anteriormente utilizado pelo deployment no Heroku)
- `package.json` ajustado, permitido que o `husky` não seja encontrado (como é o cenário de uma instalação em produção). Este workaround é sugerido pelo próprio Husky [na sua documentação](https://typicode.github.io/husky/#/?id=with-a-custom-script) 

Atualmente o bot já está hospedado no Fly.io.

Vou deixar este PR aberto uns dias a aguardar feedback, mas tendo em conta a urgência da solução (tendo em conta que o bot estava offline), vou aprovar o PR em 3 dias caso não haja feedback. 