### PR TITLE
Melhorar o comando !ja

### DIFF
--- a/domain/service/commandUseCaseResolver.ts
+++ b/domain/service/commandUseCaseResolver.ts
@@ -56,7 +56,7 @@ export default class CommandUseCaseResolver {
       "!ja": async () =>
         new SendMessageToChannelUseCase(deps).execute({
           channelId: context.channelId,
-          message: "Olá! Experimenta fazer a pergunta diretamente e contar o que já tentaste! Saiba mais aqui :point_right: https://dontasktoask.com/pt-pt/",
+          message: "Olá! Experimenta fazer a pergunta diretamente e contar o que já tentaste! Sabe mais aqui :point_right: https://dontasktoask.com/pt-pt/",
         }),
       "!oc": async () =>
         new SendMessageToChannelUseCase(deps).execute({

--- a/domain/service/commandUseCaseResolver.ts
+++ b/domain/service/commandUseCaseResolver.ts
@@ -56,7 +56,7 @@ export default class CommandUseCaseResolver {
       "!ja": async () =>
         new SendMessageToChannelUseCase(deps).execute({
           channelId: context.channelId,
-          message: ":point_right: https://dontasktoask.com/pt-pt/",
+          message: "Olá! Experimenta fazer a pergunta diretamente e contar o que já tentaste! Saiba mais aqui :point_right: https://dontasktoask.com/pt-pt/",
         }),
       "!oc": async () =>
         new SendMessageToChannelUseCase(deps).execute({


### PR DESCRIPTION
### Contexto
Apesar da maioria estar acostumado, alguém que chega ao servidor e faz perguntas ingênuas/com timidez e leva com o !ja na cara pode entender esse tipo de abordagem como arrogância. Depois de uma discussão no canal de sugestões do Discord, meio que é consenso que essa mensagem pode ser menos agressiva.

A mudança deste PR só tenta deixar o comando mais amigável ^^