### PR TITLE
Hotfix: Prevenir encerramento abrupto do bot

### DIFF
--- a/infrastructure/service/lemmyContentAggregatorService.ts
+++ b/infrastructure/service/lemmyContentAggregatorService.ts
@@ -5,22 +5,26 @@ export default class LemmyContentAggregatorService implements ContentAggregatorS
   private feedUrl = "https://lemmy.pt/api/v3/post/list?community_name=devpt&limit=10&page=1&sort=New";
 
   async fetchLastPosts(): Promise<Post[]> {
-    const response = await fetch(this.feedUrl);
+    let unpinnedPosts = [];
 
-    const data = await response.json();
+    try {
+      const response = await fetch(this.feedUrl);
 
-    const unpinnedPosts = data.posts
-      .filter((item: any) => !item.post.featured_community && !item.post.featured_local)
-      .map(
-        (item: any) =>
-          new Post({
-            authorName: item.creator.display_name || item.creator.name,
-            title: item.post.name,
-            link: item.post.ap_id,
-            description: item.post.body,
-            createdAt: new Date(item.post.published),
-          })
-      );
+      const data = await response.json();
+  
+      unpinnedPosts = data.posts
+        .filter((item: any) => !item.post.featured_community && !item.post.featured_local)
+        .map(
+          (item: any) =>
+            new Post({
+              authorName: item.creator.display_name || item.creator.name,
+              title: item.post.name,
+              link: item.post.ap_id,
+              description: item.post.body,
+              createdAt: new Date(item.post.published),
+            })
+        );
+    } catch (e) {}
 
     return unpinnedPosts;
   }


### PR DESCRIPTION
Do que nos foi possível entender, o Lemmy.pt estava offline numa das situações em que o CronJob foi tentar ir buscar novos posts.

Com este fix, devemos retornar uma coleção vazia caso aconteça alguma exceção.